### PR TITLE
[FEAT] 서버를 실행할 수 있는 파일을 생성 및 설명합니다.

### DIFF
--- a/docs/로컬에서 실행하기.md
+++ b/docs/로컬에서 실행하기.md
@@ -20,3 +20,15 @@
   ```
   bundle exec jekyll serve
   ```
+- (선택) 파일로 실행하기
+  - Mac
+    ```
+    chmod +x ./start_server.sh (한 번만 해주면 됩니다.)
+    ```
+    ```
+    ./start_server.sh
+    ```
+  - Window
+    ```
+    start_server.bat
+    ```

--- a/start_server.bat
+++ b/start_server.bat
@@ -1,0 +1,3 @@
+@echo off
+bundle exec jekyll serve
+pause

--- a/start_server.sh
+++ b/start_server.sh
@@ -1,0 +1,2 @@
+bundle exec jekyll serve
+


### PR DESCRIPTION
서버를 실행할 때마다 명령어를 찾아서 실행하는게 번거로워서 start_server.sh과(맥) start_server.bat(윈도우)에 명령어를 적어놨습니다.
사용법은 [실행 가이드](https://github.com/JNU-econovation/JNU-econovation.github.io/blob/main/docs/%EB%A1%9C%EC%BB%AC%EC%97%90%EC%84%9C%20%EC%8B%A4%ED%96%89%ED%95%98%EA%B8%B0.md)에 설명되어있습니다.

(윈도우에서 문제있다면 말씀해주세요...)