### PR TITLE
style: 블로그 썸네일 상단에 맞추기

### DIFF
--- a/_includes/custom-head.html
+++ b/_includes/custom-head.html
@@ -4,3 +4,4 @@
   1. Head over to https://realfavicongenerator.net/ to add your own favicons.
   2. Customize default _includes/custom-head.html in your source directory and insert the given code snippet.
 {% endcomment %}
+<link rel="stylesheet" href="{{ '/assets/css/custom.css' | relative_url }}">

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,5 @@
+.post-image > div {
+  background-position: top center !important;
+  background-size: cover !important;
+  background-repeat: no-repeat !important;
+}


### PR DESCRIPTION
현재 Jekyll 블로그의 썸네일이 중앙 정렬로 설정되어 있어, 세로 포스터를 제출한 팀들의 썸네일이 적절하게 표시되지 않았습니다.

모든 포스터의 썸네일을 상단 정렬하도록 하여, 세로 포스터가 상단에 맞춰 보이도록 개선했습니다. 이를 확인하기 위해서 이번 데브 회고록의 전맛탱팀과 게임팀과 4!팀을 참고하시면 됩니다. 

가로 포스터도 상단 정렬로 표시해도 레이아웃에 문제 없음을 확인했습니다.

추후 이 설정을 제거하고 싶으시면, 해당 PR 코드를 없애시면 됩니다. 